### PR TITLE
feat: add retro terminal theme

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,3 @@
-import "@fontsource-variable/geist";
-import "@fontsource-variable/geist-mono";
-
 import { PipecatClientProvider } from "@pipecat-ai/client-react";
 import SimpleVoiceUI from "./SimpleVoiceUI";
 

--- a/client/src/SimpleVoiceUI.tsx
+++ b/client/src/SimpleVoiceUI.tsx
@@ -49,7 +49,7 @@ function VoiceUI({ handleConnect, handleDisconnect, error }: VoiceUIProps) {
   }, [transportState, previousTransportState]);
   
   return (
-    <div className="min-h-screen bg-gray-900 text-gray-100 flex flex-col">
+    <div className="min-h-screen bg-black text-terminal flex flex-col">
       <Header error={!!connectionError} />
       
       {/* Main Content */}

--- a/client/src/components/ControlsArea.tsx
+++ b/client/src/components/ControlsArea.tsx
@@ -90,18 +90,18 @@ export function ControlsArea({ onConnect, onDisconnect }: ControlsAreaProps) {
   };
 
   return (
-    <div className="bg-gray-800 rounded-lg p-4 space-y-4">
+    <div className="bg-black border border-terminal/50 rounded-lg p-4 space-y-4">
       {/* Microphone Controls */}
       <div className="flex gap-4 items-center">
         <div className="flex-1">
-          <label htmlFor="microphone-select" className="block text-sm font-medium text-gray-400 mb-1">
+          <label htmlFor="microphone-select" className="block text-sm font-medium text-terminal mb-1">
             Microphone
           </label>
           <select
             id="microphone-select"
             value={selectedMicrophone}
             onChange={handleMicrophoneChange}
-            className="w-full bg-gray-700 text-gray-100 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full bg-black border border-terminal/50 text-terminal rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-terminal"
             disabled={!isConnected}
           >
             {availableMicrophones.map((mic) => (
@@ -114,12 +114,10 @@ export function ControlsArea({ onConnect, onDisconnect }: ControlsAreaProps) {
         <button
           onClick={handleToggleMute}
           disabled={!isConnected}
-          className={`px-6 py-2 rounded-lg font-medium transition-colors ${
+          className={`px-6 py-2 rounded-lg font-medium transition-colors border ${
             !isConnected
-              ? "bg-gray-700 text-gray-500 cursor-not-allowed"
-              : !isMicEnabled
-              ? "bg-red-600 hover:bg-red-700 text-white"
-              : "bg-gray-700 hover:bg-gray-600 text-gray-100"
+              ? "border-terminal/50 text-terminal/50 cursor-not-allowed"
+              : "border-terminal text-terminal hover:bg-terminal/20"
           }`}
         >
           {!isMicEnabled ? "Unmute" : "Mute"}
@@ -134,16 +132,16 @@ export function ControlsArea({ onConnect, onDisconnect }: ControlsAreaProps) {
           onChange={(e) => setInputText(e.target.value)}
           onKeyPress={handleKeyPress}
           placeholder={isConnected ? "Type a message to send to the bot..." : "Connect to send messages"}
-          className="flex-1 bg-gray-700 text-gray-100 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+          className="flex-1 bg-black border border-terminal/50 text-terminal rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-terminal disabled:opacity-50"
           disabled={!isConnected || isSending}
         />
         <button
           onClick={handleSendMessage}
           disabled={!isConnected || !inputText.trim() || isSending}
-          className={`px-6 py-2 rounded-lg font-medium transition-colors ${
+          className={`px-6 py-2 rounded-lg font-medium transition-colors border ${
             !isConnected || !inputText.trim() || isSending
-              ? "bg-gray-700 text-gray-400 cursor-not-allowed opacity-50"
-              : "bg-blue-600 hover:bg-blue-700 text-white"
+              ? "border-terminal/50 text-terminal/50 cursor-not-allowed opacity-50"
+              : "border-terminal text-terminal hover:bg-terminal/20"
           }`}
         >
           {isSending ? "Sending..." : "Send"}
@@ -154,12 +152,12 @@ export function ControlsArea({ onConnect, onDisconnect }: ControlsAreaProps) {
       <button
         onClick={handleConnectionToggle}
         disabled={isConnecting}
-        className={`w-full py-4 rounded-lg font-medium transition-colors ${
-          isConnected
-            ? "bg-red-600 hover:bg-red-700 text-white"
-            : isConnecting
-            ? "bg-yellow-600 text-white opacity-75 cursor-wait"
-            : "bg-blue-600 hover:bg-blue-700 text-white"
+        className={`w-full py-4 rounded-lg font-medium transition-colors border ${
+          isConnecting
+            ? "border-terminal/50 text-terminal/50 cursor-wait"
+            : isConnected
+            ? "bg-terminal text-black hover:bg-terminal/80 border-terminal"
+            : "border-terminal text-terminal hover:bg-terminal/20"
         }`}
       >
         {isConnected ? "Disconnect" : isConnecting ? "Connecting..." : "Start Voice Chat"}

--- a/client/src/components/EventsPanel.tsx
+++ b/client/src/components/EventsPanel.tsx
@@ -133,11 +133,11 @@ export function EventsPanel() {
   const eventGroups = groupEvents(events);
 
   return (
-    <div className="h-full bg-gray-800 rounded-lg p-4 flex flex-col">
-      <h3 className="text-sm font-medium text-gray-400 mb-2 flex-shrink-0">RTVI Events</h3>
-      <div className="flex-1 overflow-y-auto min-h-0 space-y-1 text-xs" style={{ fontFamily: 'Menlo, Monaco, "Courier New", monospace', fontSize: '11px' }}>
+    <div className="h-full bg-black border border-terminal/50 rounded-lg p-4 flex flex-col">
+      <h3 className="text-sm font-medium text-terminal mb-2 flex-shrink-0">RTVI Events</h3>
+      <div className="flex-1 overflow-y-auto min-h-0 space-y-1 text-[11px] font-mono">
         {events.length === 0 ? (
-          <div className="text-gray-600">No events yet...</div>
+          <div className="text-terminal/70">No events yet...</div>
         ) : (
           eventGroups.map((group) => {
             const isExpanded = expandedGroups.has(group.id);
@@ -150,18 +150,18 @@ export function EventsPanel() {
                   {hasMultiple && index === 0 && (
                     <button
                       onClick={() => toggleGroup(group.id)}
-                      className="text-gray-500 hover:text-gray-300 transition-colors"
+                      className="text-terminal/70 hover:text-terminal transition-colors"
                     >
                       ▼
                     </button>
                   )}
-                  {(!hasMultiple || index > 0) && <span className="text-gray-700">•</span>}
-                  <div className="flex-1 text-gray-400 truncate">
-                    <span className="text-gray-500">{event.timestamp.toLocaleTimeString()}</span>
+                  {(!hasMultiple || index > 0) && <span className="text-terminal/50">•</span>}
+                  <div className="flex-1 text-terminal truncate">
+                    <span className="text-terminal/70">{event.timestamp.toLocaleTimeString()}</span>
                     {" "}
-                    <span className="text-blue-400">{event.type}</span>:
+                    <span className="text-terminal">{event.type}</span>:
                     {" "}
-                    <span className="text-gray-300">
+                    <span className="text-terminal">
                       {event.data ? JSON.stringify(event.data).slice(0, 100) : "{}"}
                       {event.data && JSON.stringify(event.data).length > 100 ? "..." : ""}
                     </span>
@@ -174,18 +174,18 @@ export function EventsPanel() {
                 <div key={group.id} className="flex items-center gap-2">
                   <button
                     onClick={() => toggleGroup(group.id)}
-                    className="text-gray-500 hover:text-gray-300 transition-colors"
+                    className="text-terminal/70 hover:text-terminal transition-colors"
                   >
                     ▶
                   </button>
-                  <div className="flex-1 text-gray-400">
-                    <span className="text-gray-500">
+                  <div className="flex-1 text-terminal">
+                    <span className="text-terminal/70">
                       {group.events[0].timestamp.toLocaleTimeString()} - {group.events[group.events.length - 1].timestamp.toLocaleTimeString()}
                     </span>
                     {" "}
-                    <span className="text-blue-400">{group.type}</span>
+                    <span className="text-terminal">{group.type}</span>
                     {" "}
-                    <span className="text-gray-300">({group.events.length} events)</span>
+                    <span className="text-terminal">({group.events.length} events)</span>
                   </div>
                 </div>
               );

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -46,22 +46,22 @@ export function Header({ title = "ᓚᘏᗢ Pipecat", error }: HeaderProps) {
     if (isUserSpeaking) {
       return (
         <div className="flex items-center gap-2">
-          <div className="w-3 h-3 bg-blue-500 rounded-full animate-pulse" />
-          <span className="text-blue-400">User Speaking...</span>
+          <div className="w-3 h-3 bg-terminal rounded-full animate-pulse" />
+          <span className="text-terminal">User Speaking...</span>
         </div>
       );
     } else if (isBotSpeaking) {
       return (
         <div className="flex items-center gap-2">
-          <div className="w-3 h-3 bg-green-500 rounded-full animate-pulse" />
-          <span className="text-green-400">Bot Speaking...</span>
+          <div className="w-3 h-3 bg-terminal rounded-full animate-pulse" />
+          <span className="text-terminal">Bot Speaking...</span>
         </div>
       );
     } else {
       return (
         <div className="flex items-center gap-2">
-          <div className="w-3 h-3 bg-gray-600 rounded-full" />
-          <span className="text-gray-500">Ready</span>
+          <div className="w-3 h-3 bg-terminal/50 rounded-full" />
+          <span className="text-terminal/70">Ready</span>
         </div>
       );
     }
@@ -72,22 +72,28 @@ export function Header({ title = "ᓚᘏᗢ Pipecat", error }: HeaderProps) {
     const isConnecting = transportState === "connecting" || transportState === "initializing";
     
     return {
-      color: isConnected ? "bg-green-500" : isConnecting ? "bg-yellow-500" : error ? "bg-red-500" : "bg-gray-600",
-      text: isConnected ? "Connected" : isConnecting ? "Connecting..." : error ? "Error" : "Disconnected"
+      color: isConnected
+        ? "bg-terminal"
+        : isConnecting
+        ? "bg-terminal/50"
+        : error
+        ? "bg-red-500"
+        : "bg-terminal/30",
+      text: isConnected ? "Connected" : isConnecting ? "Connecting..." : error ? "Error" : "Disconnected",
     };
   };
 
   const connectionStatus = getConnectionStatus();
 
   return (
-    <header className="bg-gray-800 border-b border-gray-700 p-4">
+    <header className="bg-black border-b border-terminal/50 p-4">
       <div className="max-w-6xl mx-auto flex items-center justify-between">
-        <h1 className="text-2xl font-mono">{title}</h1>
+        <h1 className="text-terminal text-2xl font-mono">{title}</h1>
         <div className="flex items-center gap-4">
           {getSpeakingStateIndicator()}
           <div className="flex items-center gap-2">
             <div className={`w-3 h-3 rounded-full ${connectionStatus.color}`} />
-            <span className="text-sm">{connectionStatus.text}</span>
+            <span className="text-terminal text-sm">{connectionStatus.text}</span>
           </div>
         </div>
       </div>

--- a/client/src/components/MessagesPanel.tsx
+++ b/client/src/components/MessagesPanel.tsx
@@ -146,10 +146,10 @@ export function MessagesPanel() {
   );
 
   return (
-    <div className="h-full bg-gray-800 rounded-lg p-4 flex flex-col">
+    <div className="h-full bg-black border border-terminal/50 rounded-lg p-4 flex flex-col">
       <div className="flex-1 overflow-y-auto min-h-0">
         {messages.length === 0 ? (
-          <div className="text-center text-gray-500 py-8">
+          <div className="text-center text-terminal/70 py-8">
             Start a conversation by clicking the button below
           </div>
         ) : (
@@ -162,20 +162,12 @@ export function MessagesPanel() {
               }`}
             >
               <div
-                className={`max-w-[70%] rounded-lg p-4 ${
-                  message.role === 'user'
-                    ? 'bg-blue-900/50 border border-blue-700'
-                    : 'bg-gray-700 border border-gray-600'
-                }`}
+                className="max-w-[70%] bg-black border border-terminal/50 rounded-lg p-4"
               >
-                <div className={`text-xs font-medium mb-1 ${
-                  message.role === 'user' ? 'text-blue-400' : 'text-green-400'
-                }`}>
+                <div className="text-xs font-medium mb-1 text-terminal">
                   {message.role === 'user' ? 'User' : 'Bot'}
                 </div>
-                <div className={`text-sm ${
-                  message.role === 'user' ? 'text-blue-100' : 'text-gray-100'
-                }`}>
+                <div className="text-sm text-terminal">
                   {message.chunks.map((chunk, index) => (
                     <span key={chunk.id} className={
                       message.role === 'user' && !chunk.final ? 'italic opacity-70' : ''

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,5 +1,12 @@
 @import "@pipecat-ai/voice-ui-kit/styles.css";
+@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-black text-terminal font-mono;
+  }
+}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -6,7 +6,14 @@ export default {
     "./node_modules/@pipecat-ai/voice-ui-kit/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        mono: ['"VT323"', 'monospace'],
+      },
+      colors: {
+        terminal: '#00ff00',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- restyle frontend with a VT100-inspired theme: neon green text, black background, and monospace type
- apply terminal styling across header, transcript panels, event log, and control panel

## Testing
- `npm run build` *(fails: Property 'client' is missing in type '{ children: Element; }' but required in type 'Props' and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_688eae07ffc0832faae313995cb6ff35