### PR TITLE
feat: apply retro terminal theme

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Voice UI Kit Demo</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
 </head>
 <body>
     <div id="root"></div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,3 @@
-import "@fontsource-variable/geist";
-import "@fontsource-variable/geist-mono";
-
 import { PipecatClientProvider } from "@pipecat-ai/client-react";
 import SimpleVoiceUI from "./SimpleVoiceUI";
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -3,3 +3,27 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html,
+  body,
+  #root,
+  #root * {
+    background-color: #000;
+    color: #00ff00;
+    font-family: "VT323", monospace;
+    border-color: #00ff00;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    border-width: 1px;
+  }
+
+  #root button:hover {
+    background-color: #00ff00;
+    color: #000;
+  }
+}


### PR DESCRIPTION
## Summary
- switch UI to retro VT100 look with green-on-black styling and monospaced font
- remove unused geist font imports
- load VT323 Google font and apply terminal styling globally

## Testing
- `npm run build` *(fails: Property 'client' is missing in type '{ children: Element; }'...)*

------
https://chatgpt.com/codex/tasks/task_e_688eae07ffc0832faae313995cb6ff35