### PR TITLE
feat: apply retro terminal theme

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,3 @@
-import "@fontsource-variable/geist";
-import "@fontsource-variable/geist-mono";
-
 import { PipecatClientProvider } from "@pipecat-ai/client-react";
 import SimpleVoiceUI from "./SimpleVoiceUI";
 

--- a/client/src/SimpleVoiceUI.tsx
+++ b/client/src/SimpleVoiceUI.tsx
@@ -49,7 +49,7 @@ function VoiceUI({ handleConnect, handleDisconnect, error }: VoiceUIProps) {
   }, [transportState, previousTransportState]);
   
   return (
-    <div className="min-h-screen bg-gray-900 text-gray-100 flex flex-col">
+    <div className="min-h-screen bg-black text-terminal-green flex flex-col">
       <Header error={!!connectionError} />
       
       {/* Main Content */}
@@ -66,7 +66,7 @@ function VoiceUI({ handleConnect, handleDisconnect, error }: VoiceUIProps) {
         
         {/* Error Display */}
         {(error || connectionError) && (
-          <div className="bg-red-900/20 border border-red-700 rounded-lg p-4 mt-4">
+          <div className="bg-black border border-red-700 rounded p-4 mt-4">
             <p className="text-red-400 text-sm">{connectionError || error?.message || 'Connection error'}</p>
           </div>
         )}

--- a/client/src/components/ControlsArea.tsx
+++ b/client/src/components/ControlsArea.tsx
@@ -89,81 +89,65 @@ export function ControlsArea({ onConnect, onDisconnect }: ControlsAreaProps) {
     }
   };
 
-  return (
-    <div className="bg-gray-800 rounded-lg p-4 space-y-4">
-      {/* Microphone Controls */}
-      <div className="flex gap-4 items-center">
-        <div className="flex-1">
-          <label htmlFor="microphone-select" className="block text-sm font-medium text-gray-400 mb-1">
-            Microphone
-          </label>
-          <select
-            id="microphone-select"
-            value={selectedMicrophone}
-            onChange={handleMicrophoneChange}
-            className="w-full bg-gray-700 text-gray-100 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+    return (
+      <div className="bg-black border border-terminal-green rounded p-4 space-y-4">
+        {/* Microphone Controls */}
+        <div className="flex gap-4 items-center">
+          <div className="flex-1">
+            <label htmlFor="microphone-select" className="block text-sm font-medium mb-1">
+              Microphone
+            </label>
+            <select
+              id="microphone-select"
+              value={selectedMicrophone}
+              onChange={handleMicrophoneChange}
+              className="w-full bg-black border border-terminal-green text-terminal-green rounded px-4 py-2 focus:outline-none focus:ring-2 focus:ring-terminal-green disabled:opacity-50"
+              disabled={!isConnected}
+            >
+              {availableMicrophones.map((mic) => (
+                <option key={mic.deviceId} value={mic.deviceId}>
+                  {mic.label || `Microphone ${mic.deviceId.slice(0, 8)}`}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            onClick={handleToggleMute}
             disabled={!isConnected}
+            className="px-6 py-2 rounded border border-terminal-green text-terminal-green hover:bg-terminal-green/20 disabled:opacity-50"
           >
-            {availableMicrophones.map((mic) => (
-              <option key={mic.deviceId} value={mic.deviceId}>
-                {mic.label || `Microphone ${mic.deviceId.slice(0, 8)}`}
-              </option>
-            ))}
-          </select>
+            {!isMicEnabled ? "Unmute" : "Mute"}
+          </button>
         </div>
+
+        {/* Text Input */}
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={inputText}
+            onChange={(e) => setInputText(e.target.value)}
+            onKeyPress={handleKeyPress}
+            placeholder={isConnected ? "Type a message to send to the bot..." : "Connect to send messages"}
+            className="flex-1 bg-black border border-terminal-green text-terminal-green rounded px-4 py-2 focus:outline-none focus:ring-2 focus:ring-terminal-green disabled:opacity-50 placeholder-terminal-green/50"
+            disabled={!isConnected || isSending}
+          />
+          <button
+            onClick={handleSendMessage}
+            disabled={!isConnected || !inputText.trim() || isSending}
+            className="px-6 py-2 rounded border border-terminal-green text-terminal-green hover:bg-terminal-green/20 disabled:opacity-50"
+          >
+            {isSending ? "Sending..." : "Send"}
+          </button>
+        </div>
+
+        {/* Voice Control Button */}
         <button
-          onClick={handleToggleMute}
-          disabled={!isConnected}
-          className={`px-6 py-2 rounded-lg font-medium transition-colors ${
-            !isConnected
-              ? "bg-gray-700 text-gray-500 cursor-not-allowed"
-              : !isMicEnabled
-              ? "bg-red-600 hover:bg-red-700 text-white"
-              : "bg-gray-700 hover:bg-gray-600 text-gray-100"
-          }`}
+          onClick={handleConnectionToggle}
+          disabled={isConnecting}
+          className="w-full py-4 rounded border border-terminal-green text-terminal-green hover:bg-terminal-green/20 disabled:opacity-50"
         >
-          {!isMicEnabled ? "Unmute" : "Mute"}
+          {isConnected ? "Disconnect" : isConnecting ? "Connecting..." : "Start Voice Chat"}
         </button>
       </div>
-
-      {/* Text Input */}
-      <div className="flex gap-2">
-        <input
-          type="text"
-          value={inputText}
-          onChange={(e) => setInputText(e.target.value)}
-          onKeyPress={handleKeyPress}
-          placeholder={isConnected ? "Type a message to send to the bot..." : "Connect to send messages"}
-          className="flex-1 bg-gray-700 text-gray-100 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
-          disabled={!isConnected || isSending}
-        />
-        <button
-          onClick={handleSendMessage}
-          disabled={!isConnected || !inputText.trim() || isSending}
-          className={`px-6 py-2 rounded-lg font-medium transition-colors ${
-            !isConnected || !inputText.trim() || isSending
-              ? "bg-gray-700 text-gray-400 cursor-not-allowed opacity-50"
-              : "bg-blue-600 hover:bg-blue-700 text-white"
-          }`}
-        >
-          {isSending ? "Sending..." : "Send"}
-        </button>
-      </div>
-
-      {/* Voice Control Button */}
-      <button
-        onClick={handleConnectionToggle}
-        disabled={isConnecting}
-        className={`w-full py-4 rounded-lg font-medium transition-colors ${
-          isConnected
-            ? "bg-red-600 hover:bg-red-700 text-white"
-            : isConnecting
-            ? "bg-yellow-600 text-white opacity-75 cursor-wait"
-            : "bg-blue-600 hover:bg-blue-700 text-white"
-        }`}
-      >
-        {isConnected ? "Disconnect" : isConnecting ? "Connecting..." : "Start Voice Chat"}
-      </button>
-    </div>
-  );
+    );
 }

--- a/client/src/components/EventsPanel.tsx
+++ b/client/src/components/EventsPanel.tsx
@@ -132,63 +132,63 @@ export function EventsPanel() {
 
   const eventGroups = groupEvents(events);
 
-  return (
-    <div className="h-full bg-gray-800 rounded-lg p-4 flex flex-col">
-      <h3 className="text-sm font-medium text-gray-400 mb-2 flex-shrink-0">RTVI Events</h3>
-      <div className="flex-1 overflow-y-auto min-h-0 space-y-1 text-xs" style={{ fontFamily: 'Menlo, Monaco, "Courier New", monospace', fontSize: '11px' }}>
-        {events.length === 0 ? (
-          <div className="text-gray-600">No events yet...</div>
-        ) : (
-          eventGroups.map((group) => {
+    return (
+      <div className="h-full bg-black border border-terminal-green rounded p-4 flex flex-col">
+        <h3 className="text-sm font-medium mb-2 flex-shrink-0">RTVI Events</h3>
+        <div className="flex-1 overflow-y-auto min-h-0 space-y-1 text-xs" style={{ fontFamily: 'Menlo, Monaco, \"Courier New\", monospace', fontSize: '11px' }}>
+          {events.length === 0 ? (
+            <div className="opacity-50">No events yet...</div>
+          ) : (
+            eventGroups.map((group) => {
             const isExpanded = expandedGroups.has(group.id);
             const hasMultiple = group.events.length > 1;
             
             if (!hasMultiple || isExpanded) {
               // Show all events in the group
               return group.events.map((event, index) => (
-                <div key={event.id} className="flex items-center gap-2">
-                  {hasMultiple && index === 0 && (
-                    <button
-                      onClick={() => toggleGroup(group.id)}
-                      className="text-gray-500 hover:text-gray-300 transition-colors"
-                    >
-                      ▼
-                    </button>
-                  )}
-                  {(!hasMultiple || index > 0) && <span className="text-gray-700">•</span>}
-                  <div className="flex-1 text-gray-400 truncate">
-                    <span className="text-gray-500">{event.timestamp.toLocaleTimeString()}</span>
-                    {" "}
-                    <span className="text-blue-400">{event.type}</span>:
-                    {" "}
-                    <span className="text-gray-300">
-                      {event.data ? JSON.stringify(event.data).slice(0, 100) : "{}"}
-                      {event.data && JSON.stringify(event.data).length > 100 ? "..." : ""}
-                    </span>
+                  <div key={event.id} className="flex items-center gap-2">
+                    {hasMultiple && index === 0 && (
+                      <button
+                        onClick={() => toggleGroup(group.id)}
+                        className="opacity-50 hover:opacity-100 transition-colors"
+                      >
+                        ▼
+                      </button>
+                    )}
+                    {(!hasMultiple || index > 0) && <span className="opacity-50">•</span>}
+                    <div className="flex-1 truncate">
+                      <span className="opacity-50">{event.timestamp.toLocaleTimeString()}</span>
+                      {" "}
+                      <span>{event.type}</span>:
+                      {" "}
+                      <span>
+                        {event.data ? JSON.stringify(event.data).slice(0, 100) : "{}"}
+                        {event.data && JSON.stringify(event.data).length > 100 ? "..." : ""}
+                      </span>
+                    </div>
                   </div>
-                </div>
-              ));
+                ));
             } else {
               // Show collapsed group
-              return (
-                <div key={group.id} className="flex items-center gap-2">
-                  <button
-                    onClick={() => toggleGroup(group.id)}
-                    className="text-gray-500 hover:text-gray-300 transition-colors"
-                  >
-                    ▶
-                  </button>
-                  <div className="flex-1 text-gray-400">
-                    <span className="text-gray-500">
-                      {group.events[0].timestamp.toLocaleTimeString()} - {group.events[group.events.length - 1].timestamp.toLocaleTimeString()}
-                    </span>
-                    {" "}
-                    <span className="text-blue-400">{group.type}</span>
-                    {" "}
-                    <span className="text-gray-300">({group.events.length} events)</span>
+                return (
+                  <div key={group.id} className="flex items-center gap-2">
+                    <button
+                      onClick={() => toggleGroup(group.id)}
+                      className="opacity-50 hover:opacity-100 transition-colors"
+                    >
+                      ▶
+                    </button>
+                    <div className="flex-1">
+                      <span className="opacity-50">
+                        {group.events[0].timestamp.toLocaleTimeString()} - {group.events[group.events.length - 1].timestamp.toLocaleTimeString()}
+                      </span>
+                      {" "}
+                      <span>{group.type}</span>
+                      {" "}
+                      <span>({group.events.length} events)</span>
+                    </div>
                   </div>
-                </div>
-              );
+                );
             }
           })
         )}

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -46,22 +46,22 @@ export function Header({ title = "ᓚᘏᗢ Pipecat", error }: HeaderProps) {
     if (isUserSpeaking) {
       return (
         <div className="flex items-center gap-2">
-          <div className="w-3 h-3 bg-blue-500 rounded-full animate-pulse" />
-          <span className="text-blue-400">User Speaking...</span>
+          <div className="w-3 h-3 bg-terminal-green rounded-full animate-pulse" />
+          <span>User Speaking...</span>
         </div>
       );
     } else if (isBotSpeaking) {
       return (
         <div className="flex items-center gap-2">
-          <div className="w-3 h-3 bg-green-500 rounded-full animate-pulse" />
-          <span className="text-green-400">Bot Speaking...</span>
+          <div className="w-3 h-3 bg-terminal-green rounded-full animate-pulse" />
+          <span>Bot Speaking...</span>
         </div>
       );
     } else {
       return (
         <div className="flex items-center gap-2">
-          <div className="w-3 h-3 bg-gray-600 rounded-full" />
-          <span className="text-gray-500">Ready</span>
+          <div className="w-3 h-3 bg-terminal-green opacity-50 rounded-full" />
+          <span className="opacity-50">Ready</span>
         </div>
       );
     }
@@ -72,17 +72,29 @@ export function Header({ title = "ᓚᘏᗢ Pipecat", error }: HeaderProps) {
     const isConnecting = transportState === "connecting" || transportState === "initializing";
     
     return {
-      color: isConnected ? "bg-green-500" : isConnecting ? "bg-yellow-500" : error ? "bg-red-500" : "bg-gray-600",
-      text: isConnected ? "Connected" : isConnecting ? "Connecting..." : error ? "Error" : "Disconnected"
+      color: isConnected
+        ? "bg-terminal-green"
+        : isConnecting
+        ? "bg-terminal-green opacity-50"
+        : error
+        ? "bg-red-600"
+        : "bg-terminal-green opacity-25",
+      text: isConnected
+        ? "Connected"
+        : isConnecting
+        ? "Connecting..."
+        : error
+        ? "Error"
+        : "Disconnected"
     };
   };
 
   const connectionStatus = getConnectionStatus();
 
   return (
-    <header className="bg-gray-800 border-b border-gray-700 p-4">
+    <header className="bg-black border-b border-terminal-green p-4">
       <div className="max-w-6xl mx-auto flex items-center justify-between">
-        <h1 className="text-2xl font-mono">{title}</h1>
+        <h1 className="text-2xl">{title}</h1>
         <div className="flex items-center gap-4">
           {getSpeakingStateIndicator()}
           <div className="flex items-center gap-2">

--- a/client/src/components/MessagesPanel.tsx
+++ b/client/src/components/MessagesPanel.tsx
@@ -145,53 +145,48 @@ export function MessagesPanel() {
     }, [])
   );
 
-  return (
-    <div className="h-full bg-gray-800 rounded-lg p-4 flex flex-col">
-      <div className="flex-1 overflow-y-auto min-h-0">
-        {messages.length === 0 ? (
-          <div className="text-center text-gray-500 py-8">
-            Start a conversation by clicking the button below
-          </div>
-        ) : (
-          <div className="space-y-4">
-          {messages.map((message) => (
-            <div
-              key={message.id}
-              className={`flex ${
-                message.role === 'user' ? 'justify-end' : 'justify-start'
-              }`}
-            >
-              <div
-                className={`max-w-[70%] rounded-lg p-4 ${
-                  message.role === 'user'
-                    ? 'bg-blue-900/50 border border-blue-700'
-                    : 'bg-gray-700 border border-gray-600'
-                }`}
-              >
-                <div className={`text-xs font-medium mb-1 ${
-                  message.role === 'user' ? 'text-blue-400' : 'text-green-400'
-                }`}>
-                  {message.role === 'user' ? 'User' : 'Bot'}
-                </div>
-                <div className={`text-sm ${
-                  message.role === 'user' ? 'text-blue-100' : 'text-gray-100'
-                }`}>
-                  {message.chunks.map((chunk, index) => (
-                    <span key={chunk.id} className={
-                      message.role === 'user' && !chunk.final ? 'italic opacity-70' : ''
-                    }>
-                      {chunk.text}
-                      {index < message.chunks.length - 1 ? ' ' : ''}
-                    </span>
-                  ))}
-                </div>
-              </div>
+    return (
+      <div className="h-full bg-black border border-terminal-green rounded p-4 flex flex-col">
+        <div className="flex-1 overflow-y-auto min-h-0">
+          {messages.length === 0 ? (
+            <div className="text-center opacity-50 py-8">
+              Start a conversation by clicking the button below
             </div>
-          ))}
-          <div ref={messagesEndRef} />
+          ) : (
+            <div className="space-y-4">
+              {messages.map((message) => (
+                <div
+                  key={message.id}
+                  className={`flex ${
+                    message.role === 'user' ? 'justify-end' : 'justify-start'
+                  }`}
+                >
+                  <div className="max-w-[70%] rounded border border-terminal-green p-4">
+                    <div className="text-xs font-medium mb-1">
+                      {message.role === 'user' ? 'User' : 'Bot'}
+                    </div>
+                    <div className="text-sm">
+                      {message.chunks.map((chunk, index) => (
+                        <span
+                          key={chunk.id}
+                          className={
+                            message.role === 'user' && !chunk.final
+                              ? 'italic opacity-70'
+                              : ''
+                          }
+                        >
+                          {chunk.text}
+                          {index < message.chunks.length - 1 ? ' ' : ''}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ))}
+              <div ref={messagesEndRef} />
+            </div>
+          )}
         </div>
-      )}
       </div>
-    </div>
-  );
+    );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,5 +1,12 @@
 @import "@pipecat-ai/voice-ui-kit/styles.css";
+@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-black text-terminal-green font-mono;
+  }
+}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -6,7 +6,14 @@ export default {
     "./node_modules/@pipecat-ai/voice-ui-kit/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'terminal-green': '#00ff00',
+      },
+      fontFamily: {
+        mono: ['"VT323"', 'monospace'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- Add VT323 font and terminal-green color in Tailwind config
- Apply black background and neon green text across UI components
- Simplify controls with monospaced, retro styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: TS2741 property 'client' missing, TS2786 'AudioClientHelper' not valid JSX, TS2339 'updateMicrophone' does not exist, TS2307 cannot find module './ResizablePanels')*

------
https://chatgpt.com/codex/tasks/task_e_688eae07ffc0832faae313995cb6ff35